### PR TITLE
fix null pointer panic for nested struct

### DIFF
--- a/twist.go
+++ b/twist.go
@@ -368,9 +368,7 @@ func cascadeCli(v reflect.Value, cliOptions map[string][]string, cloned map[stri
 			if vv, ok := cliOptions[name]; ok {
 				cliValue = vv
 				found = true
-				if _, ok := cloned[name]; ok {
-					delete(cloned, name)
-				}
+				delete(cloned, name)
 				break
 			}
 		}

--- a/twist_test.go
+++ b/twist_test.go
@@ -15,7 +15,8 @@ func TestMixCli(t *testing.T) {
 			Host string `cli:"h,host"`
 			Port int    `cli:"p,port"`
 		}
-		Long string `cli:"long"`
+		Long           string `cli:"long"`
+		DuplicatedHost string `cli:"h,host"`
 	}{}
 	// Actually provide from os.Args[1:]
 	args := []string{"-h", "cli.localhost", "--port=9000", "--token", "token_from_cli", "-long", "foo"}
@@ -28,6 +29,7 @@ func TestMixCli(t *testing.T) {
 	assert.Equal(t, "cli.localhost", config.Server.Host)
 	assert.Equal(t, 9000, config.Server.Port)
 	assert.Equal(t, "foo", config.Long)
+	assert.Equal(t, "cli.localhost", config.DuplicatedHost)
 }
 
 func TestMixIni(t *testing.T) {


### PR DESCRIPTION
This PR avoids causing panic with a null pointer on the nested struct.
If the nested struct field is a struct and it's nil, call `reflect.New()` to allocate a pointer.